### PR TITLE
Allows for specifying test verbosity via Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.dir>${basedir}/src/main/checkstyle</checkstyle.dir>
     <assembly.dir>${basedir}/src/main/assembly</assembly.dir>
+    <verbosity>0</verbosity>            
   </properties>
 
   <dependencies>
@@ -175,6 +176,12 @@
         <configuration>
           <parallel>methods</parallel>
           <threadCount>10</threadCount>
+          <properties>
+            <property>
+              <name>surefire.testng.verbose</name>
+              <value>${verbosity}</value>
+            </property>
+          </properties>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.dir>${basedir}/src/main/checkstyle</checkstyle.dir>
     <assembly.dir>${basedir}/src/main/assembly</assembly.dir>
-    <verbosity>0</verbosity>            
+    <testng.verbosity>0</testng.verbosity>
   </properties>
 
   <dependencies>
@@ -179,7 +179,7 @@
           <properties>
             <property>
               <name>surefire.testng.verbose</name>
-              <value>${verbosity}</value>
+              <value>${testng.verbosity}</value>
             </property>
           </properties>
         </configuration>


### PR DESCRIPTION
ex:
mvn -Dverbosity=10 test
See: Level of Verbosity at https://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html