### PR TITLE
Avoid time-based nonces.

### DIFF
--- a/src/main/java/org/cryptacular/generator/RandomIdGenerator.java
+++ b/src/main/java/org/cryptacular/generator/RandomIdGenerator.java
@@ -1,8 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.cryptacular.generator;
 
-import org.bouncycastle.crypto.digests.SHA256Digest;
-import org.cryptacular.util.NonceUtil;
+import java.security.SecureRandom;
 
 /**
  * Generates random identifiers with an alphanumeric character set by default.
@@ -21,6 +20,8 @@ public class RandomIdGenerator implements IdGenerator
   /** Identifier character set. */
   private final String charset;
 
+  /** Source of randomness. */
+  private final SecureRandom secureRandom;
 
   /**
    * Creates a new instance with the default character set.
@@ -49,6 +50,8 @@ public class RandomIdGenerator implements IdGenerator
       throw new IllegalArgumentException("Charset length must be in the range 2 - 128");
     }
     this.charset = charset;
+    secureRandom = new SecureRandom();
+    secureRandom.setSeed(secureRandom.generateSeed(16));
   }
 
 
@@ -57,11 +60,7 @@ public class RandomIdGenerator implements IdGenerator
   {
     final StringBuilder id = new StringBuilder(length);
     final byte[] output = new byte[length];
-    final int outsize = NonceUtil.newRBG(new SHA256Digest(), 32).generate(output, null, false);
-    if (outsize < length) {
-      throw new IllegalStateException("Insufficient entropy");
-    }
-
+    secureRandom.nextBytes(output);
     int index;
     for (int i = 0; i < output.length && id.length() < length; i++) {
       index = 0x7F & output[i];

--- a/src/main/java/org/cryptacular/generator/RandomIdGenerator.java
+++ b/src/main/java/org/cryptacular/generator/RandomIdGenerator.java
@@ -51,7 +51,8 @@ public class RandomIdGenerator implements IdGenerator
     }
     this.charset = charset;
     secureRandom = new SecureRandom();
-    secureRandom.setSeed(secureRandom.generateSeed(16));
+    // Call nextBytes to force seeding via default process
+    secureRandom.nextBytes(new byte[1]);
   }
 
 

--- a/src/main/java/org/cryptacular/generator/SecretKeyGenerator.java
+++ b/src/main/java/org/cryptacular/generator/SecretKeyGenerator.java
@@ -45,7 +45,7 @@ public final class SecretKeyGenerator
   public static SecretKey generate(final int bitLength, final BlockCipher cipher)
   {
     // Want as much nonce data as key bits
-    final byte[] nonce = NonceUtil.timestampNonce((bitLength + 7) / 8);
+    final byte[] nonce = NonceUtil.randomNonce((bitLength + 7) / 8);
     return generate(bitLength, cipher, new SP800SecureRandomBuilder().buildHash(new SHA256Digest(), nonce, false));
   }
 

--- a/src/main/java/org/cryptacular/generator/sp80038a/EncryptedNonce.java
+++ b/src/main/java/org/cryptacular/generator/sp80038a/EncryptedNonce.java
@@ -58,7 +58,7 @@ public class EncryptedNonce implements Nonce
     throws LimitException
   {
     final byte[] result = new byte[cipher.getBlockSize()];
-    final byte[] nonce = NonceUtil.timestampNonce(result.length);
+    final byte[] nonce = NonceUtil.randomNonce(result.length);
     synchronized (cipher) {
       cipher.init(true, new KeyParameter(key.getEncoded()));
       cipher.processBlock(nonce, 0, result, 0);

--- a/src/main/java/org/cryptacular/generator/sp80038d/RBGNonce.java
+++ b/src/main/java/org/cryptacular/generator/sp80038d/RBGNonce.java
@@ -2,7 +2,6 @@
 package org.cryptacular.generator.sp80038d;
 
 import org.bouncycastle.crypto.digests.SHA256Digest;
-import org.bouncycastle.crypto.prng.EntropySource;
 import org.bouncycastle.crypto.prng.drbg.HashSP800DRBG;
 import org.bouncycastle.crypto.prng.drbg.SP80090DRBG;
 import org.cryptacular.generator.LimitException;
@@ -112,30 +111,7 @@ public class RBGNonce implements Nonce
    */
   private static SP80090DRBG newRBG(final int length, final byte[] domain)
   {
-    return
-      new HashSP800DRBG(
-        new SHA256Digest(),
-        length,
-        new EntropySource() {
-          @Override
-          public boolean isPredictionResistant()
-          {
-            return false;
-          }
-
-          @Override
-          public byte[] getEntropy()
-          {
-            return NonceUtil.timestampNonce(length);
-          }
-
-          @Override
-          public int entropySize()
-          {
-            return length;
-          }
-        },
-        domain,
-        NonceUtil.timestampNonce(8));
+    return new HashSP800DRBG(
+        new SHA256Digest(), length, NonceUtil.randomEntropySource(length), domain, NonceUtil.timestampNonce(8));
   }
 }

--- a/src/main/java/org/cryptacular/util/NonceUtil.java
+++ b/src/main/java/org/cryptacular/util/NonceUtil.java
@@ -27,7 +27,8 @@ public final class NonceUtil
   /** Seed random source. */
   static
   {
-    SECURE_RANDOM.setSeed(SECURE_RANDOM.generateSeed(16));
+    // Call nextBytes to force seeding via default process
+    SECURE_RANDOM.nextBytes(new byte[1]);
   }
 
   /** Private constructor of utility class. */

--- a/src/main/java/org/cryptacular/util/NonceUtil.java
+++ b/src/main/java/org/cryptacular/util/NonceUtil.java
@@ -2,6 +2,7 @@
 package org.cryptacular.util;
 
 import java.lang.reflect.Method;
+import java.security.SecureRandom;
 import javax.crypto.SecretKey;
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.Digest;
@@ -20,6 +21,14 @@ import org.cryptacular.generator.sp80038d.RBGNonce;
  */
 public final class NonceUtil
 {
+  /** Class-wide random source. */
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  /** Seed random source. */
+  static
+  {
+    SECURE_RANDOM.setSeed(SECURE_RANDOM.generateSeed(16));
+  }
 
   /** Private constructor of utility class. */
   private NonceUtil() {}
@@ -50,6 +59,57 @@ public final class NonceUtil
       }
     }
     return nonce;
+  }
+
+
+  /**
+   * Generates a random nonce of the given length in bytes.
+   *
+   * @param  length  Positive number of bytes in nonce.
+   *
+   * @return  Nonce bytes.
+   */
+  public static byte[] randomNonce(final int length)
+  {
+    if (length <= 0) {
+      throw new IllegalArgumentException(length + " is invalid. Length must be positive.");
+    }
+    final byte[] nonce = new byte[length];
+    SECURE_RANDOM.nextBytes(nonce);
+    return nonce;
+  }
+
+
+  /**
+   * Creates a new entropy source that wraps a {@link SecureRandom} to produce random bytes.
+   *
+   * @param length Size of entropy blocks.
+   *
+   * @return New random entropy source.
+   */
+  public static EntropySource randomEntropySource(final int length)
+  {
+    return new EntropySource() {
+      @Override
+      public boolean isPredictionResistant()
+      {
+        return true;
+      }
+
+      @Override
+      public byte[] getEntropy()
+      {
+        final byte[] bytes = new byte[length];
+        SECURE_RANDOM.nextBytes(bytes);
+        return bytes;
+      }
+
+      @Override
+      public int entropySize()
+      {
+        return length;
+      }
+    };
   }
 
 
@@ -106,7 +166,7 @@ public final class NonceUtil
    */
   public static byte[] nist80063a(final SP800SecureRandom prng, final int blockSize)
   {
-    prng.setSeed(System.nanoTime());
+    prng.setSeed(randomNonce(blockSize));
 
     final byte[] iv = new byte[blockSize];
     prng.nextBytes(iv);
@@ -154,30 +214,21 @@ public final class NonceUtil
    */
   public static SP80090DRBG newRBG(final Digest digest, final int length)
   {
-    return
-      new HashSP800DRBG(
-        digest,
-        length,
-        new EntropySource() {
-          @Override
-          public boolean isPredictionResistant()
-          {
-            return false;
-          }
+    return newRBG(digest, length, randomEntropySource(length));
+  }
 
-          @Override
-          public byte[] getEntropy()
-          {
-            return NonceUtil.timestampNonce(length);
-          }
-
-          @Override
-          public int entropySize()
-          {
-            return length;
-          }
-        },
-        null,
-        NonceUtil.timestampNonce(8));
+  /**
+   * Creates a new hash-based DRBG instance that uses the given digest as the pseudorandom source.
+   *
+   * @param  digest  Digest algorithm.
+   * @param  length  Length in bits of values to be produced by DRBG instance.
+   * @param  es  Entropy source.
+   *
+   * @return  New DRGB instance.
+   */
+  public static SP80090DRBG newRBG(final Digest digest, final int length, final EntropySource es)
+  {
+    return new HashSP800DRBG(
+        digest, length, es, Thread.currentThread().getName().getBytes(), NonceUtil.timestampNonce(8));
   }
 }


### PR DESCRIPTION
Use a properly seeded SecureRandom as a source of random data for nonces
and secure random sequence generation (e.g. RandomIdGenerator).

Fixed #40