### PR TITLE
Add bcrypt hash support.

### DIFF
--- a/src/main/java/org/cryptacular/SaltedHash.java
+++ b/src/main/java/org/cryptacular/SaltedHash.java
@@ -66,6 +66,22 @@ public class SaltedHash
     return salt;
   }
 
+  /**
+   * Gets N bytes of salt.
+   *
+   * @param n Number of bytes of salt; must be less than or equal to salt size.
+   *
+   * @return First N bytes of salt.
+   */
+  public byte[] getSalt(final int n) {
+    if (n > salt.length) {
+      throw new IllegalArgumentException("Requested size exceeded length: " + n + ">" + salt.length);
+    }
+    final byte[] bytes = new byte[n];
+    System.arraycopy(salt, 0, bytes, 0, n);
+    return bytes;
+  }
+
 
   /**
    * Gets an encoded string of the concatenation of digest output and salt.

--- a/src/main/java/org/cryptacular/SaltedHash.java
+++ b/src/main/java/org/cryptacular/SaltedHash.java
@@ -73,7 +73,8 @@ public class SaltedHash
    *
    * @return First N bytes of salt.
    */
-  public byte[] getSalt(final int n) {
+  public byte[] getSalt(final int n)
+  {
     if (n > salt.length) {
       throw new IllegalArgumentException("Requested size exceeded length: " + n + ">" + salt.length);
     }

--- a/src/main/java/org/cryptacular/bean/BCryptHashBean.java
+++ b/src/main/java/org/cryptacular/bean/BCryptHashBean.java
@@ -1,0 +1,320 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.cryptacular.bean;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import org.bouncycastle.crypto.generators.BCrypt;
+import org.cryptacular.CryptoException;
+import org.cryptacular.StreamException;
+import org.cryptacular.codec.Base64Decoder;
+import org.cryptacular.codec.Base64Encoder;
+import org.cryptacular.codec.Decoder;
+import org.cryptacular.codec.Encoder;
+import org.cryptacular.util.ByteUtil;
+
+/**
+ * {@link HashBean} implementation that uses the <em>bcrypt</em> algorithm for hashing. Hash strings of the following
+ * format are supported:
+ * <br>
+ * <code><pre>
+ *   $2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+ *
+ *   where:
+ *     n is an optional bcrypt algorithm version (typically "a" or "b")
+ *     4 &le; cost &le; 31
+ *     x is 22 characters of encoded salt
+ *     y is 31 characters of encoded hash bytes
+ * </pre></code>
+ * <p>
+ * The encoding for salt and hash bytes is a variant of base-64 encoding without padding in the following alphabet:
+ * <br>
+ * <code>./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789</code>
+ *
+ * @author  Middleware Services
+ */
+public class BCryptHashBean implements HashBean<String>
+{
+  /** Custom base-64 alphabet. */
+  private static final String ALPHABET = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  /** BCrypt cost factor in the range [4, 31]. */
+  private final int cost;
+
+  /** BCrypt version used when computing hashes. */
+  private String version = "2b";
+
+
+  /**
+   * Creates a new instance that uses the given cost factor when hashing.
+   *
+   * @param costFactor BCrypt cost in the range [4, 31].
+   */
+  public BCryptHashBean(final int costFactor)
+  {
+    if (costFactor < 4 || costFactor > 31) {
+      throw new IllegalArgumentException("Cost must be in the range [4, 31].");
+    }
+    cost = costFactor;
+  }
+
+
+  /**
+   * Sets the bcrypt version.
+   *
+   * @param  ver  Bcrypt version, e.g. "2b"
+   */
+  public void setVersion(final String ver)
+  {
+    if (!ver.startsWith("2") && ver.length() <= 2) {
+      throw new IllegalArgumentException("Invalid version");
+    }
+    version = ver;
+  }
+
+  /**
+   * Compute a bcrypt hash of the form <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>
+   * given a salt and a password.
+   * @param  data  A 2-element array containing salt and password. The salt may be encoded per the bcrypt standard
+   *               or raw bytes.
+   *
+   * @return An encoded bcrypt hash, <code>yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code> in the specification above.
+   *
+   * @throws CryptoException on bcrypt algorithm errors.
+   */
+  @Override
+  public String hash(final Object... data) throws CryptoException
+  {
+    if (data.length != 2) {
+      throw new IllegalArgumentException("Expected exactly two elements in data array but got " + data.length);
+    }
+    return encode(BCrypt.generate(password(version, data[1]), salt(data[0]), cost), 23);
+  }
+
+
+  /**
+   * Compares a bcrypt hash of the form <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>
+   * with the computed hash from the given password. The bcrypt algorithm parameters are derived from the reference
+   * bcrypt hash string.
+   *
+   * @param  data  A 1-element array containing password.
+   *
+   * @return True if the computed hash is exactly equal to the reference hash, false otherwise.
+   *
+   * @throws CryptoException on bcrypt algorithm errors.
+   */
+  @Override
+  public boolean compare(final String hash, final Object... data) throws CryptoException, StreamException
+  {
+    if (data.length != 1) {
+      throw new IllegalArgumentException("Expected exactly one element in data array but got " + data.length);
+    }
+    final BCryptParameters params = new BCryptParameters(hash);
+    final byte[] computed = BCrypt.generate(password(params.getVersion(), data[0]), params.getSalt(), params.getCost());
+    for (int i = 0; i < 23; i++) {
+      if (params.getHash()[i] != computed[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+  /**
+   * Encodes an input byte array into a string using the configured encoder.
+   *
+   * @param  bytes  Input bytes to encode.
+   * @param  length  Number of bytes of input to encode.
+   *
+   * @return  Input encoded as a string.
+   */
+  private static String encode(final byte[] bytes, final int length)
+  {
+    final Encoder encoder = new Base64Encoder.Builder().setAlphabet(ALPHABET).setPadding(false).build();
+    // Only want 184 bits (23 bytes) of the output
+    final ByteBuffer input = ByteBuffer.wrap(bytes, 0, length);
+    final CharBuffer output = CharBuffer.allocate(encoder.outputSize(length));
+    encoder.encode(input, output);
+    encoder.finalize(output);
+    return output.flip().toString();
+  }
+
+
+  /**
+   * Decodes an input string into a byte array using the configured decoder.
+   *
+   * @param  input  Input string to decode.
+   * @param  length  Desired output size in bytes.
+   *
+   * @return  Input decoded as a byte array.
+   */
+  private static byte[] decode(final String input, final int length)
+  {
+    final Decoder decoder = new Base64Decoder.Builder().setAlphabet(ALPHABET).setPadding(false).build();
+    final ByteBuffer output = ByteBuffer.allocate(decoder.outputSize(input.length()));
+    decoder.decode(CharBuffer.wrap(input), output);
+    decoder.finalize(output);
+    output.flip();
+    if (output.limit() != length) {
+      throw new IllegalArgumentException("Input is not of the expected size: " + output.limit() + "!=" + length);
+    }
+    return ByteUtil.toArray(output);
+  }
+
+
+  /**
+   * Converts an input object into a salt as an array of bytes.
+   *
+   * @param  data  Input salt as a byte array or encoded string.
+   *
+   * @return  Salt as byte array.
+   */
+  private static byte[] salt(final Object data)
+  {
+    if (data instanceof byte[]) {
+      return (byte[]) data;
+    } else if (data instanceof String) {
+      return decode((String) data, 16);
+    }
+    throw new IllegalArgumentException("Expected byte array or base-64 string.");
+  }
+
+
+  /**
+   * Converts an input object into a password as an array of UTF-8 bytes.
+   *
+   * @param  version  Bcrypt version, e.g. "2a".
+   * @param  data  Input password.
+   *
+   * @return  Password as UTF-8 byte array.
+   */
+  private static byte[] password(final String version, final Object data)
+  {
+    if (data instanceof byte[]) {
+      return (byte[]) data;
+    }
+    final StringBuilder sb = new StringBuilder();
+    if (data instanceof char[]) {
+      sb.append((char[]) data);
+    } else if (data instanceof String) {
+      sb.append((String) data);
+    } else {
+      throw new IllegalArgumentException("Expected byte array or string.");
+    }
+    if (version.length() > 1) {
+      // Version 2a and later requires null terminator on password
+      sb.append('\0');
+    }
+    return sb.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+
+  /**
+   * Handles encoding and decoding a bcrypt hash of the form
+   * <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>.
+   */
+  public static class BCryptParameters
+  {
+    /** bcrypt version. */
+    private final String version;
+
+    /** bcrypt cost. */
+    private final int cost;
+
+    /** bcrypt salt. */
+    private final byte[] salt;
+
+    /** bcrypt hash. */
+    private final byte[] hash;
+
+
+    /**
+     * Decodes bcrypt parameters from a string.
+     *
+     * @param  bCryptString  bcrypt hash of the form
+     *                       <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>
+     */
+    protected BCryptParameters(final String bCryptString)
+    {
+      if (!bCryptString.startsWith("$2")) {
+        throw new IllegalArgumentException("Expected bcrypt hash of the form $2n$cost$salthash");
+      }
+      final String[] parts = bCryptString.split("\\$");
+      if (parts.length != 4) {
+        throw new IllegalArgumentException("Invalid bcrypt hash");
+      }
+      version = parts[1];
+      cost = Integer.parseInt(parts[2]);
+      salt = decode(parts[3].substring(0, 22), 16);
+      hash = decode(parts[3].substring(22), 23);
+    }
+
+
+    /** @return  bcrypt version. */
+    public String getVersion()
+    {
+      return version;
+    }
+
+
+    /** @return  bcrypt cost in the range [4, 31]. */
+    public int getCost()
+    {
+      return cost;
+    }
+
+
+    /** @return  bcrypt salt. */
+    public byte[] getSalt()
+    {
+      return salt;
+    }
+
+
+    /** @return  bcrypt hash. */
+    public byte[] getHash()
+    {
+      return hash;
+    }
+
+
+    /**
+     * Produces an encoded bcrypt hash string from bcrypt parameter data.
+     *
+     * @return  Bcrypt hash of the form <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>.
+     */
+    public String encode()
+    {
+      return new StringBuilder(60)
+          .append('$')
+          .append(version)
+          .append('$')
+          .append(cost)
+          .append('$')
+          .append(BCryptHashBean.encode(salt, 16))
+          .append(BCryptHashBean.encode(hash, 23))
+          .toString();
+    }
+
+
+    /**
+     * Produces an encoded bcrypt hash string from bcrypt parameters and a provided hash string.
+     *
+     * @param  hash  Encoded bcrypt hash bytes; e.g. the value produced from {@link #hash(Object...)}.
+     *
+     * @return  Bcrypt hash of the form <code>$2n$cost$xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</code>.
+     */
+    public String encode(final String hash)
+    {
+      return new StringBuilder(60)
+          .append('$')
+          .append(version)
+          .append('$')
+          .append(cost)
+          .append('$')
+          .append(BCryptHashBean.encode(salt, 16))
+          .append(hash)
+          .toString();
+    }
+  }
+}

--- a/src/main/java/org/cryptacular/codec/AbstractBaseNDecoder.java
+++ b/src/main/java/org/cryptacular/codec/AbstractBaseNDecoder.java
@@ -3,7 +3,6 @@ package org.cryptacular.codec;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.cryptacular.EncodingException;
 
 /**
@@ -23,6 +22,9 @@ public abstract class AbstractBaseNDecoder implements Decoder
   /** Current position in character block. */
   private int blockPos;
 
+  /** Flag indicating whether input is padded. True by default. */
+  private boolean paddedInput = true;
+
 
   /**
    * Creates a new instance with given parameters.
@@ -35,18 +37,36 @@ public abstract class AbstractBaseNDecoder implements Decoder
   }
 
 
+  /** @return  True if padded input is accepted (default), false otherwise. */
+  public boolean isPaddedInput()
+  {
+    return paddedInput;
+  }
+
+
+  /**
+   * Determines whether padded input is accepted.
+   *
+   * @param  enabled  True to enable support for padded input, false otherwise.
+   */
+  public void setPaddedInput(final boolean enabled)
+  {
+    this.paddedInput = enabled;
+  }
+
+
   @Override
   public void decode(final CharBuffer input, final ByteBuffer output) throws EncodingException
   {
     char current;
     while (input.hasRemaining()) {
       current = input.get();
-      if (Character.isWhitespace(current)) {
+      if (Character.isWhitespace(current) || current == '=') {
         continue;
       }
       block[blockPos++] = current;
       if (blockPos == block.length) {
-        writeOutput(output);
+        writeOutput(output, block.length);
       }
     }
   }
@@ -56,7 +76,7 @@ public abstract class AbstractBaseNDecoder implements Decoder
   public void finalize(final ByteBuffer output) throws EncodingException
   {
     if (blockPos > 0) {
-      writeOutput(output);
+      writeOutput(output, blockPos);
     }
   }
 
@@ -64,7 +84,14 @@ public abstract class AbstractBaseNDecoder implements Decoder
   @Override
   public int outputSize(final int inputSize)
   {
-    return inputSize * getBitsPerChar() / 8;
+    final int size;
+    if (paddedInput) {
+      size = inputSize;
+    } else {
+      // For unpadded input, add the maximum number of padding characters to get worst-case estimate
+      size = inputSize + getBlockLength() / 8 - 1;
+    }
+    return size * getBitsPerChar() / 8;
   }
 
 
@@ -77,22 +104,41 @@ public abstract class AbstractBaseNDecoder implements Decoder
 
 
   /**
+   * Converts the given alphabet into a base-N decoding table.
+   *
+   * @param  alphabet  Decoding alphabet to use.
+   * @param  n  Encoding base.
+   *
+   * @return  Decoding table of 128 elements.
+   */
+  protected static byte[] decodingTable(final String alphabet, final int n)
+  {
+    if (alphabet.length() != n) {
+      throw new IllegalArgumentException("Alphabet must be exactly " + n + " characters long");
+    }
+    final byte[] decodingTable = new byte[128];
+    for (int i = 0; i < n; i++) {
+      decodingTable[(int) alphabet.charAt(i)] = (byte) i;
+    }
+    return decodingTable;
+  }
+
+
+  /**
    * Writes bytes in the current encoding block to the output buffer.
    *
    * @param  output  Output buffer.
+   * @param  len  Number of characters to decode in current block.
    */
-  private void writeOutput(final ByteBuffer output)
+  private void writeOutput(final ByteBuffer output, final int len)
   {
     long b;
     long value = 0;
     int shift = getBlockLength();
-    for (char c : block) {
-      if (c == '=') {
-        break;
-      }
-      b = table[c & 0x7F];
+    for (int i = 0; i < len; i++) {
+      b = table[block[i] & 0x7F];
       if (b < 0) {
-        throw new EncodingException("Invalid character " + c);
+        throw new EncodingException("Invalid character " + block[i]);
       }
       shift -= getBitsPerChar();
       value |= b << shift;

--- a/src/main/java/org/cryptacular/codec/AbstractBaseNEncoder.java
+++ b/src/main/java/org/cryptacular/codec/AbstractBaseNEncoder.java
@@ -3,7 +3,6 @@ package org.cryptacular.codec;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.cryptacular.EncodingException;
 
 /**
@@ -41,6 +40,9 @@ public abstract class AbstractBaseNEncoder implements Encoder
   /** Number of characters written. */
   private int outCount;
 
+  /** Flag indicating whether output is padded. True by default. */
+  private boolean paddedOutput = true;
+
 
   /**
    * Creates a new instance with given parameters.
@@ -58,6 +60,26 @@ public abstract class AbstractBaseNEncoder implements Encoder
     }
     initialBitMask = mask;
     lineLength = charactersPerLine;
+  }
+
+
+  /**
+   * @return True if padded output is enabled (default), false otherwise.
+   */
+  public boolean isPaddedOutput()
+  {
+    return paddedOutput;
+  }
+
+
+  /**
+   * Sets the output padding mode.
+   *
+   * @param  enabled  True to enable padded output, false otherwise.
+   */
+  public void setPaddedOutput(final boolean enabled)
+  {
+    this.paddedOutput = enabled;
   }
 
 
@@ -81,8 +103,10 @@ public abstract class AbstractBaseNEncoder implements Encoder
       // Floor division
       final int stop = remaining / bitsPerChar * bitsPerChar;
       writeOutput(output, stop);
-      for (int i = stop; i > 0; i -= bitsPerChar) {
-        output.put('=');
+      if (paddedOutput) {
+        for (int i = stop; i > 0; i -= bitsPerChar) {
+          output.put('=');
+        }
       }
     }
     // Append trailing newline to make consistent with OpenSSL base64 output
@@ -110,6 +134,27 @@ public abstract class AbstractBaseNEncoder implements Encoder
 
   /** @return  Number of bits encoding a single character. */
   protected abstract int getBitsPerChar();
+
+
+  /**
+   * Converts the given alphabet into a base-N encoding table.
+   *
+   * @param  alphabet  Encoding alphabet to use.
+   * @param  n  Encoding base.
+   *
+   * @return  Encoding table of N elements.
+   */
+  protected static char[] encodingTable(final String alphabet, final int n)
+  {
+    if (alphabet.length() != n) {
+      throw new IllegalArgumentException("Alphabet must be exactly " + n + " characters long");
+    }
+    final char[] encodingTable = new char[n];
+    for (int i = 0; i < n; i++) {
+      encodingTable[i] = alphabet.charAt(i);
+    }
+    return encodingTable;
+  }
 
 
   /**

--- a/src/main/java/org/cryptacular/codec/Base32Codec.java
+++ b/src/main/java/org/cryptacular/codec/Base32Codec.java
@@ -10,10 +10,54 @@ public class Base32Codec implements Codec
 {
 
   /** Encoder. */
-  private final Encoder encoder = new Base32Encoder();
+  private final Encoder encoder;
 
   /** Decoder. */
-  private final Decoder decoder = new Base32Decoder();
+  private final Decoder decoder;
+
+  /** Custom alphabet to use. */
+  private final String customAlphabet;
+
+  /** Whether input/output padding is supported. */
+  private final boolean padding;
+
+
+  /**
+   * Creates a new instance using the RFC 4328 alphabet, <code>ABCDEFGHIJKLMNOPQRSTUVWXYZ234567</code>.
+   */
+  public Base32Codec()
+  {
+    encoder = new Base32Encoder();
+    decoder = new Base32Decoder();
+    customAlphabet = null;
+    padding = true;
+  }
+
+
+  /**
+   * Creates a new instance using the given 32-character alphabet.
+   *
+   * @param  alphabet  32-character alphabet to use.
+   */
+  public Base32Codec(final String alphabet)
+  {
+    this(alphabet, true);
+  }
+
+
+  /**
+   * Creates a new instance using the given 32-character alphabet with option to enable/disable padding.
+   *
+   * @param  alphabet  32-character alphabet to use.
+   * @param  inputOutputPadding  True to enable support for padding, false otherwise.
+   */
+  public Base32Codec(final String alphabet, final boolean inputOutputPadding)
+  {
+    customAlphabet = alphabet;
+    padding = inputOutputPadding;
+    encoder = newEncoder();
+    decoder = newDecoder();
+  }
 
 
   @Override
@@ -26,6 +70,34 @@ public class Base32Codec implements Codec
   @Override
   public Decoder getDecoder()
   {
+    return decoder;
+  }
+
+
+  @Override
+  public Encoder newEncoder()
+  {
+    final Base32Encoder encoder;
+    if (customAlphabet != null) {
+      encoder = new Base32Encoder(customAlphabet);
+    } else {
+      encoder = new Base32Encoder();
+    }
+    encoder.setPaddedOutput(padding);
+    return encoder;
+  }
+
+
+  @Override
+  public Decoder newDecoder()
+  {
+    final Base32Decoder decoder;
+    if (customAlphabet != null) {
+      decoder = new Base32Decoder(customAlphabet);
+    } else {
+      decoder = new Base32Decoder();
+    }
+    decoder.setPaddedInput(padding);
     return decoder;
   }
 }

--- a/src/main/java/org/cryptacular/codec/Base32Decoder.java
+++ b/src/main/java/org/cryptacular/codec/Base32Decoder.java
@@ -1,8 +1,6 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.cryptacular.codec;
 
-import java.util.Arrays;
-
 /**
  * Stateful base 32 decoder with support for line breaks.
  *
@@ -12,25 +10,32 @@ public class Base32Decoder extends AbstractBaseNDecoder
 {
 
   /** Base-32 character decoding table. */
-  private static final byte[] DECODING_TABLE = new byte[128];
+  private static final byte[] DECODING_TABLE;
 
 
   /* Initializes the character decoding table. */
-  static {
-    Arrays.fill(DECODING_TABLE, (byte) -1);
-    for (int i = 0; i < 26; i++) {
-      DECODING_TABLE[i + 65] = (byte) i;
-    }
-    for (int i = 0; i < 6; i++) {
-      DECODING_TABLE[i + 50] = (byte) (i + 26);
-    }
+  static
+  {
+    DECODING_TABLE = decodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 32);
   }
 
-
-  /** Creates a new instance. */
+  /**
+   * Creates a new instance using the RFC 4648 alphabet, <code>ABCDEFGHIJKLMNOPQRSTUVWXYZ234567</code>, for decoding.
+   */
   public Base32Decoder()
   {
     super(DECODING_TABLE);
+  }
+
+
+  /**
+   * Creates a new instance using the given 32-character alphabet for decoding.
+   *
+   * @param  alphabet  32-character alphabet to use.
+   */
+  public Base32Decoder(final String alphabet)
+  {
+    super(decodingTable(alphabet, 32));
   }
 
 

--- a/src/main/java/org/cryptacular/codec/Base32Encoder.java
+++ b/src/main/java/org/cryptacular/codec/Base32Encoder.java
@@ -10,19 +10,20 @@ public class Base32Encoder extends AbstractBaseNEncoder
 {
 
   /** Base 32 character encoding table. */
-  private static final char[] ENCODING_TABLE = new char[32];
+  private static final char[] ENCODING_TABLE;
 
 
-  /* Initializes the encoding character table. */
-  static {
-    final String charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-    for (int i = 0; i < charset.length(); i++) {
-      ENCODING_TABLE[i] = charset.charAt(i);
-    }
+  /* Initializes the default character encoding table. */
+  static
+  {
+    ENCODING_TABLE = encodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", 32);
   }
 
 
-  /** Creates a new instance that produces base 32-encoded output with no line breaks. */
+  /**
+   * Creates a new instance that produces base 32-encoded output in the RFC 4648 alphabet,
+   * <code>ABCDEFGHIJKLMNOPQRSTUVWXYZ234567</code>, with no line breaks in the output.
+   */
   public Base32Encoder()
   {
     // Default to no line breaks.
@@ -31,14 +32,39 @@ public class Base32Encoder extends AbstractBaseNEncoder
 
 
   /**
-   * Creates a new instance that produces base 32-encoded output with the given number of characters per line in the
-   * default character set.
+   * Creates a new instance that produces base 32-encoded output in the RFC 4648 alphabet,
+   * <code>ABCDEFGHIJKLMNOPQRSTUVWXYZ234567</code>, with the given number of characters per line in the output.
    *
    * @param  charactersPerLine  Number of characters per line. A zero or negative value disables line breaks.
    */
   public Base32Encoder(final int charactersPerLine)
   {
     super(ENCODING_TABLE, charactersPerLine);
+  }
+
+
+  /**
+   * Creates a new instance that produces base 32-encoded output in the given 32-character alphabet with no line
+   * breaks in the output.
+   *
+   * @param  alphabet  32-character alphabet to use.
+   */
+  public Base32Encoder(final String alphabet)
+  {
+    this(alphabet, -1);
+  }
+
+
+  /**
+   * Creates a new instance that produces base 32-encoded output in the given 32-character alphabet
+   * with the given number of characters per line in the output.
+   *
+   * @param  alphabet  32-character alphabet to use.
+   * @param  charactersPerLine  Number of characters per line. A zero or negative value disables line breaks.
+   */
+  public Base32Encoder(final String alphabet, final int charactersPerLine)
+  {
+    super(encodingTable(alphabet, 32), charactersPerLine);
   }
 
 

--- a/src/main/java/org/cryptacular/codec/Base64Codec.java
+++ b/src/main/java/org/cryptacular/codec/Base64Codec.java
@@ -10,10 +10,54 @@ public class Base64Codec implements Codec
 {
 
   /** Encoder. */
-  private final Encoder encoder = new Base64Encoder();
+  private final Encoder encoder;
 
   /** Decoder. */
-  private final Decoder decoder = new Base64Decoder();
+  private final Decoder decoder;
+
+  /** Custom alphabet to use. */
+  private final String customAlphabet;
+
+  /** Whether input/output padding is supported. */
+  private final boolean padding;
+
+
+  /**
+   * Creates a new instance using the base-64 alphabet defined in RFC 4648.
+   */
+  public Base64Codec()
+  {
+    encoder = new Base64Encoder();
+    decoder = new Base64Decoder();
+    customAlphabet = null;
+    padding = true;
+  }
+
+
+  /**
+   * Creates a new instance using the given 64-character alphabet.
+   *
+   * @param  alphabet  64-character alphabet to use.
+   */
+  public Base64Codec(final String alphabet)
+  {
+    this(alphabet, true);
+  }
+
+
+  /**
+   * Creates a new instance using the given 64-character alphabet with option to enable/disable padding.
+   *
+   * @param  alphabet  64-character alphabet to use.
+   * @param  inputOutputPadding  True to enable support for padding, false otherwise.
+   */
+  public Base64Codec(final String alphabet, final boolean inputOutputPadding)
+  {
+    customAlphabet = alphabet;
+    padding = inputOutputPadding;
+    encoder = newEncoder();
+    decoder = newDecoder();
+  }
 
 
   @Override
@@ -26,6 +70,34 @@ public class Base64Codec implements Codec
   @Override
   public Decoder getDecoder()
   {
+    return decoder;
+  }
+
+
+  @Override
+  public Encoder newEncoder()
+  {
+    final Base64Encoder encoder;
+    if (customAlphabet != null) {
+      encoder = new Base64Encoder(customAlphabet);
+    } else {
+      encoder = new Base64Encoder();
+    }
+    encoder.setPaddedOutput(padding);
+    return encoder;
+  }
+
+
+  @Override
+  public Decoder newDecoder()
+  {
+    final Base64Decoder decoder;
+    if (customAlphabet != null) {
+      decoder = new Base64Decoder(customAlphabet);
+    } else {
+      decoder = new Base64Decoder();
+    }
+    decoder.setPaddedInput(padding);
     return decoder;
   }
 }

--- a/src/main/java/org/cryptacular/codec/Base64Decoder.java
+++ b/src/main/java/org/cryptacular/codec/Base64Decoder.java
@@ -1,8 +1,6 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.cryptacular.codec;
 
-import java.util.Arrays;
-
 /**
  * Stateful base 64 decoder with support for line breaks.
  *
@@ -12,29 +10,17 @@ public class Base64Decoder extends AbstractBaseNDecoder
 {
 
   /** Default base-64 character decoding table. */
-  private static final byte[] DEFAULT_DECODING_TABLE = new byte[128];
+  private static final byte[] DEFAULT_DECODING_TABLE;
 
   /** URL and filesystem-safe base-64 character decoding table. */
-  private static final byte[] URLSAFE_DECODING_TABLE = new byte[128];
+  private static final byte[] URLSAFE_DECODING_TABLE;
 
 
   /* Initializes the character decoding table. */
-  static {
-    Arrays.fill(DEFAULT_DECODING_TABLE, (byte) -1);
-    for (int i = 0; i < 26; i++) {
-      DEFAULT_DECODING_TABLE[i + 65] = (byte) i;
-    }
-    for (int i = 0; i < 26; i++) {
-      DEFAULT_DECODING_TABLE[i + 97] = (byte) (i + 26);
-    }
-    for (int i = 0; i < 10; i++) {
-      DEFAULT_DECODING_TABLE[i + 48] = (byte) (i + 52);
-    }
-    System.arraycopy(DEFAULT_DECODING_TABLE, 0, URLSAFE_DECODING_TABLE, 0, 128);
-    DEFAULT_DECODING_TABLE[43] = (byte) 62;
-    DEFAULT_DECODING_TABLE[47] = (byte) 63;
-    URLSAFE_DECODING_TABLE[45] = (byte) 62;
-    URLSAFE_DECODING_TABLE[95] = (byte) 63;
+  static
+  {
+    DEFAULT_DECODING_TABLE = decodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", 64);
+    URLSAFE_DECODING_TABLE = decodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_", 64);
   }
 
 
@@ -56,6 +42,17 @@ public class Base64Decoder extends AbstractBaseNDecoder
   }
 
 
+  /**
+   * Creates a new instance that decodes base-64 character data encoded in the given alphabet.
+   *
+   * @param  alphabet  Base-64 alphabet to use for decoding
+   */
+  public Base64Decoder(final String alphabet)
+  {
+    super(decodingTable(alphabet, 64));
+  }
+
+
   @Override
   protected int getBlockLength()
   {
@@ -67,5 +64,81 @@ public class Base64Decoder extends AbstractBaseNDecoder
   protected int getBitsPerChar()
   {
     return 6;
+  }
+
+
+  /**
+   * Builder for base-64 decoders.
+   */
+  public static class Builder
+  {
+    /** URL-safe alphabet flag. */
+    private boolean urlSafe;
+
+    /** Arbitrary alphbet. */
+    private String alphabet;
+
+    /** Padding flag. */
+    private boolean padding;
+
+
+    /**
+     * Sets the URL-safe alphabet flag.
+     *
+     * @param safe True for URL-safe alphabet, false otherwise.
+     *
+     * @return This instance.
+     */
+    public Builder setUrlSafe(final boolean safe)
+    {
+      urlSafe = safe;
+      return this;
+    }
+
+
+    /**
+     * Sets an arbitrary 64-character alphabet for decoding.
+     *
+     * @param alpha Alternative alphabet.
+     *
+     * @return This instance.
+     */
+    public Builder setAlphabet(final String alpha)
+    {
+      alphabet = alpha;
+      return this;
+    }
+
+
+    /**
+     * Sets padding flag on the decoder.
+     *
+     * @param pad True for base-64 padding, false otherwise.
+     *
+     * @return This instance.
+     */
+    public Builder setPadding(final boolean pad)
+    {
+      padding = pad;
+      return this;
+    }
+
+
+    /**
+     * Builds a base-64 decoder with the given options.
+     *
+     * @return New base-64 decoder instance.
+     */
+    public Base64Decoder build()
+    {
+      final Base64Decoder decoder;
+      if (alphabet != null) {
+        decoder = new Base64Decoder(alphabet);
+      } else {
+        decoder = new Base64Decoder(urlSafe);
+      }
+      decoder.setPaddedInput(padding);
+      return decoder;
+    }
   }
 }

--- a/src/main/java/org/cryptacular/codec/Base64Encoder.java
+++ b/src/main/java/org/cryptacular/codec/Base64Encoder.java
@@ -10,21 +10,17 @@ public class Base64Encoder extends AbstractBaseNEncoder
 {
 
   /** Default base 64 character encoding table. */
-  private static final char[] DEFAULT_ENCODING_TABLE = new char[64];
+  private static final char[] DEFAULT_ENCODING_TABLE;
 
   /** Filesystem and URL-safe base 64 character encoding table. */
-  private static final char[] URLSAFE_ENCODING_TABLE = new char[64];
+  private static final char[] URLSAFE_ENCODING_TABLE;
 
 
-  /* Initializes the encoding character table. */
-  static {
-    final String defaultCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    for (int i = 0; i < defaultCharset.length(); i++) {
-      DEFAULT_ENCODING_TABLE[i] = defaultCharset.charAt(i);
-      URLSAFE_ENCODING_TABLE[i] = defaultCharset.charAt(i);
-    }
-    URLSAFE_ENCODING_TABLE[62] = '-';
-    URLSAFE_ENCODING_TABLE[63] = '_';
+  /* Initializes the default character encoding tables. */
+  static
+  {
+    DEFAULT_ENCODING_TABLE = encodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", 64);
+    URLSAFE_ENCODING_TABLE = encodingTable("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_", 64);
   }
 
 
@@ -73,6 +69,30 @@ public class Base64Encoder extends AbstractBaseNEncoder
   }
 
 
+  /**
+   * Creates a new instance that produces base 64-encoded output with the given 64-character alphabet.
+   *
+   * @param  alphabet  64-character alphabet to use.
+   */
+  public Base64Encoder(final String alphabet)
+  {
+    this(alphabet, -1);
+  }
+
+
+  /**
+   * Creates a new instance that produces base 64-encoded output with the given 64-character alphabet with line
+   * wrapping at the specified line length;
+   *
+   * @param  alphabet  64-character alphabet to use.
+   * @param  charactersPerLine  Number of characters per line. A zero or negative value disables line breaks.
+   */
+  public Base64Encoder(final String alphabet, final int charactersPerLine)
+  {
+    super(encodingTable(alphabet, 64), charactersPerLine);
+  }
+
+
   @Override
   protected int getBlockLength()
   {
@@ -84,5 +104,98 @@ public class Base64Encoder extends AbstractBaseNEncoder
   protected int getBitsPerChar()
   {
     return 6;
+  }
+
+
+  /**
+   * Builder for base-64 encoders.
+   */
+  public static class Builder
+  {
+    /** URL-safe alphabet flag. */
+    private boolean urlSafe;
+
+    /** Arbitrary alphbet. */
+    private String alphabet;
+
+    /** Padding flag. */
+    private boolean padding;
+
+    /** Number of base-64 characters per line in output. */
+    private int charactersPerLine = -1;
+
+
+    /**
+     * Sets the URL-safe alphabet flag.
+     *
+     * @param  safe  True for URL-safe alphabet, false otherwise.
+     *
+     * @return  This instance.
+     */
+    public Base64Encoder.Builder setUrlSafe(final boolean safe)
+    {
+      urlSafe = safe;
+      return this;
+    }
+
+
+    /**
+     * Sets an arbitrary 64-character alphabet for encoding.
+     *
+     * @param  alpha  Alternative alphabet.
+     *
+     * @return  This instance.
+     */
+    public Base64Encoder.Builder setAlphabet(final String alpha)
+    {
+      alphabet = alpha;
+      return this;
+    }
+
+
+    /**
+     * Sets padding flag on the encoder.
+     *
+     * @param  pad  True for base-64 padding, false otherwise.
+     *
+     * @return  This instance.
+     */
+    public Base64Encoder.Builder setPadding(final boolean pad)
+    {
+      padding = pad;
+      return this;
+    }
+
+
+    /**
+     * Sets the number of characters per line in output produced by the encoder.
+     *
+     * @param  lineLength  Number of characters per line. Set to <code>-1</code> to suppress line breaks.
+     *
+     * @return  This instance.
+     */
+    public Base64Encoder.Builder setCharactersPerLine(final int lineLength)
+    {
+      charactersPerLine = lineLength;
+      return this;
+    }
+
+
+    /**
+     * Builds a base-64 encoder with the given options.
+     *
+     * @return  New base-64 encoder instance.
+     */
+    public Base64Encoder build()
+    {
+      final Base64Encoder decoder;
+      if (alphabet != null) {
+        decoder = new Base64Encoder(alphabet, charactersPerLine);
+      } else {
+        decoder = new Base64Encoder(urlSafe, charactersPerLine);
+      }
+      decoder.setPaddedOutput(padding);
+      return decoder;
+    }
   }
 }

--- a/src/main/java/org/cryptacular/codec/Codec.java
+++ b/src/main/java/org/cryptacular/codec/Codec.java
@@ -15,4 +15,11 @@ public interface Codec
 
   /** @return  The char-to-byte decoder of the codec pair. */
   Decoder getDecoder();
+
+  /** @return  A new instance of the byte-to-char encoder of the codec pair. */
+  Encoder newEncoder();
+
+
+  /** @return  A new instance of the char-to-byte decoder of the codec pair. */
+  Decoder newDecoder();
 }

--- a/src/main/java/org/cryptacular/codec/Codec.java
+++ b/src/main/java/org/cryptacular/codec/Codec.java
@@ -9,12 +9,14 @@ package org.cryptacular.codec;
 public interface Codec
 {
 
+
   /** @return  The byte-to-char encoder of the codec pair. */
   Encoder getEncoder();
 
 
   /** @return  The char-to-byte decoder of the codec pair. */
   Decoder getDecoder();
+
 
   /** @return  A new instance of the byte-to-char encoder of the codec pair. */
   Encoder newEncoder();

--- a/src/main/java/org/cryptacular/codec/HexCodec.java
+++ b/src/main/java/org/cryptacular/codec/HexCodec.java
@@ -28,4 +28,18 @@ public class HexCodec implements Codec
   {
     return decoder;
   }
+
+
+  @Override
+  public Encoder newEncoder()
+  {
+    return new HexEncoder();
+  }
+
+
+  @Override
+  public Decoder newDecoder()
+  {
+    return new HexDecoder();
+  }
 }

--- a/src/main/java/org/cryptacular/util/ByteUtil.java
+++ b/src/main/java/org/cryptacular/util/ByteUtil.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-
 import org.cryptacular.StreamException;
 
 /**
@@ -236,12 +235,12 @@ public final class ByteUtil
    */
   public static byte[] toArray(final ByteBuffer buffer)
   {
-    if (buffer.limit() == buffer.capacity()) {
+    final int size = buffer.limit() - buffer.position();
+    if (buffer.hasArray() && size == buffer.capacity()) {
       return buffer.array();
     }
 
-    final byte[] array = new byte[buffer.limit()];
-    buffer.position(0);
+    final byte[] array = new byte[size];
     buffer.get(array);
     return array;
   }

--- a/src/test/java/org/cryptacular/bean/BCryptHashBeanTest.java
+++ b/src/test/java/org/cryptacular/bean/BCryptHashBeanTest.java
@@ -1,0 +1,42 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.cryptacular.bean;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test for {@link BCryptHashBean} class.
+ *
+ * @author Middleware Services
+ */
+public class BCryptHashBeanTest
+{
+  @DataProvider(name = "hashes")
+  public Object[][] getHashData()
+  {
+    return
+      new Object[][] {
+        {"password", "$2a$5$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe"},
+        {"x", "$2a$12$w6IdiZTAckGirKaH8LU8VOxEvP97cFLEW5ePVJzhZilSa5c.V/uMK"},
+        {"abcdefghijklmnopqrstuvwxyz", "$2a$6$.rCVZVOThsIa97pEDOxvGuRRgzG64bvtJ0938xuqzv18d3ZpQhstC"},
+        {"abcdefghijklmnopqrstuvwxyz", "$2a$8$aTsUwsyowQuzRrDqFflhgekJ8d9/7Z3GV3UcgvzQW3J5zMyrTvlz."},
+      };
+  }
+
+  @Test(dataProvider = "hashes")
+  public void testHash(final String password, final String expected)
+  {
+    final BCryptHashBean.BCryptParameters params = new BCryptHashBean.BCryptParameters(expected);
+    final String hash = new BCryptHashBean(params.getCost()).hash(params.getSalt(), password);
+    assertEquals(params.encode(hash), expected);
+  }
+
+  @Test(dataProvider = "hashes")
+  public void testCompare(final String password, final String expected)
+  {
+    assertTrue(new BCryptHashBean(10).compare(expected, password));
+  }
+}

--- a/src/test/java/org/cryptacular/codec/Base32DecoderTest.java
+++ b/src/test/java/org/cryptacular/codec/Base32DecoderTest.java
@@ -24,6 +24,8 @@ public class Base32DecoderTest
   @DataProvider(name = "encoded-data")
   public Object[][] getEncodedData()
   {
+    final Base32Decoder unpadded = new Base32Decoder();
+    unpadded.setPaddedInput(false);
     return
       new Object[][] {
         // Multiple of 40 bits
@@ -34,8 +36,8 @@ public class Base32DecoderTest
         },
         // Final quantum of encoding input is exactly 8 bits
         new Object[] {
-          new Base32Decoder(),
-          "43H7CNN2EI======",
+          unpadded,
+          "43H7CNN2EI",
           CodecUtil.hex("e6cff135ba22"),
         },
         // Final quantum of encoding input is exactly 16 bits

--- a/src/test/java/org/cryptacular/codec/Base32EncoderTest.java
+++ b/src/test/java/org/cryptacular/codec/Base32EncoderTest.java
@@ -23,6 +23,8 @@ public class Base32EncoderTest
   @DataProvider(name = "byte-data")
   public Object[][] getByteData()
   {
+    final Base32Encoder unpadded = new Base32Encoder();
+    unpadded.setPaddedOutput(false);
     return
       new Object[][] {
         // Multiple of 40 bits
@@ -45,9 +47,9 @@ public class Base32EncoderTest
         },
         // Final quantum of encoding input is exactly 24 bits
         new Object[] {
-          new Base32Encoder(),
+          unpadded,
           CodecUtil.hex("5d6a416513f176ca"),
-          "LVVECZIT6F3MU===",
+          "LVVECZIT6F3MU",
         },
         // Final quantum of encoding input is exactly 32 bits
         new Object[] {

--- a/src/test/java/org/cryptacular/codec/Base64DecoderTest.java
+++ b/src/test/java/org/cryptacular/codec/Base64DecoderTest.java
@@ -8,6 +8,7 @@ import java.nio.CharBuffer;
 
 import org.cryptacular.FailListener;
 import org.cryptacular.util.ByteUtil;
+import org.cryptacular.util.CodecUtil;
 import org.cryptacular.util.HashUtil;
 import org.cryptacular.util.StreamUtil;
 import org.testng.annotations.DataProvider;
@@ -46,9 +47,19 @@ public class Base64DecoderTest
           HashUtil.sha1(ByteUtil.toBytes("t3stUs3r01")),
         },
         new Object[] {
-          new Base64Decoder(true),
+          new Base64Decoder.Builder().setUrlSafe(true).build(),
           "safx_LW8-SsSy_o3PmCNy4VEm5s=",
           HashUtil.sha1(ByteUtil.toBytes("t3stUs3r01")),
+        },
+        new Object[] {
+          new Base64Decoder.Builder().setUrlSafe(true).setPadding(false).build(),
+          "FPu_A9l-",
+          CodecUtil.hex("14FBBF03D97E"),
+        },
+        new Object[] {
+          new Base64Decoder.Builder().setUrlSafe(true).setPadding(false).build(),
+          "FPu_A9k",
+          CodecUtil.hex("14FBBF03D9"),
         },
       };
   }

--- a/src/test/java/org/cryptacular/codec/Base64EncoderTest.java
+++ b/src/test/java/org/cryptacular/codec/Base64EncoderTest.java
@@ -9,6 +9,7 @@ import java.nio.channels.FileChannel;
 
 import org.cryptacular.FailListener;
 import org.cryptacular.util.ByteUtil;
+import org.cryptacular.util.CodecUtil;
 import org.cryptacular.util.HashUtil;
 import org.cryptacular.util.StreamUtil;
 import org.testng.annotations.DataProvider;
@@ -28,12 +29,19 @@ public class Base64EncoderTest
   @DataProvider(name = "byte-data")
   public Object[][] getByteData()
   {
+    final Base64Encoder unpadded = new Base64Encoder();
+    unpadded.setPaddedOutput(false);
     return
       new Object[][] {
         new Object[] {
           new Base64Encoder(),
           ByteUtil.toBytes("Able was I ere I saw elba"),
           "QWJsZSB3YXMgSSBlcmUgSSBzYXcgZWxiYQ==",
+        },
+        new Object[] {
+          new Base64Encoder.Builder().setPadding(false).build(),
+          ByteUtil.toBytes("Able was I ere I saw elba"),
+          "QWJsZSB3YXMgSSBlcmUgSSBzYXcgZWxiYQ",
         },
         new Object[] {
           new Base64Encoder(),
@@ -49,6 +57,21 @@ public class Base64EncoderTest
           new Base64Encoder(true),
           HashUtil.sha1(ByteUtil.toBytes("t3stUs3r01")),
           "safx_LW8-SsSy_o3PmCNy4VEm5s=",
+        },
+        new Object[] {
+          new Base64Encoder(),
+          CodecUtil.hex("3f1c435a244f7a8be1572a1bf2a196f4958cc00c17b96e"),
+          "PxxDWiRPeovhVyob8qGW9JWMwAwXuW4=",
+        },
+        new Object[] {
+          new Base64Encoder.Builder().setUrlSafe(true).setPadding(false).build(),
+          CodecUtil.hex("14FBBF03D97E"),
+          "FPu_A9l-",
+        },
+        new Object[] {
+          new Base64Encoder.Builder().setUrlSafe(true).setPadding(false).build(),
+          CodecUtil.hex("14FBBF03D9"),
+          "FPu_A9k",
         },
       };
   }


### PR DESCRIPTION
Includes a fair bit of work with base32/64 encoding components to support arbitrary alphabets and lack of padding, but these features could be considered general improvements in themselves.

Fixes #39.