### PR TITLE
issue-47 Add flag for uppercase Hex output.

### DIFF
--- a/src/main/java/org/cryptacular/codec/HexCodec.java
+++ b/src/main/java/org/cryptacular/codec/HexCodec.java
@@ -10,10 +10,34 @@ public class HexCodec implements Codec
 {
 
   /** Encoder. */
-  private final Encoder encoder = new HexEncoder();
+  private final Encoder encoder;
 
   /** Decoder. */
   private final Decoder decoder = new HexDecoder();
+
+  /** True to encode in uppercase characters, false otherwise. */
+  private final boolean uppercase;
+
+
+  /**
+   * Creates a new instance that outputs lowercase hex characters and supports decoding in either case.
+   */
+  public HexCodec()
+  {
+    this(false);
+  }
+
+
+  /**
+   * Creates a new instance that optionally outputs uppercase hex characters and supports decoding in either case.
+   *
+   * @param  uppercaseOutput  True to output uppercase alphabetic characters, false for lowercase.
+   */
+  public HexCodec(final boolean uppercaseOutput)
+  {
+    uppercase = uppercaseOutput;
+    encoder = new HexEncoder(uppercase);
+  }
 
 
   @Override
@@ -33,7 +57,7 @@ public class HexCodec implements Codec
   @Override
   public Encoder newEncoder()
   {
-    return new HexEncoder();
+    return new HexEncoder(uppercase);
   }
 
 

--- a/src/main/java/org/cryptacular/codec/HexEncoder.java
+++ b/src/main/java/org/cryptacular/codec/HexEncoder.java
@@ -13,36 +13,54 @@ import org.cryptacular.EncodingException;
 public class HexEncoder implements Encoder
 {
 
-  /** Hex character encoding table. */
-  private static final char[] ENCODING_TABLE = new char[16];
+  /** Lowercase hex character encoding table. */
+  private static final char[] LC_ENCODING_TABLE = new char[16];
+
+  /** Uppercase hex character encoding table. */
+  private static final char[] UC_ENCODING_TABLE = new char[16];
+
 
 
   /* Initializes the encoding character table. */
   static {
-    final String charset = "0123456789abcdef";
-    for (int i = 0; i < charset.length(); i++) {
-      ENCODING_TABLE[i] = charset.charAt(i);
-    }
+    initTable("0123456789abcdef", LC_ENCODING_TABLE);
+    initTable("0123456789ABCDEF", UC_ENCODING_TABLE);
   }
 
   /** Flag indicating whether to delimit every two characters with ':' as in key fingerprints, etc. */
   private final boolean delimit;
 
+  /** Encoding table to use. */
+  private final char[] table;
+
 
   /** Creates a new instance that does not delimit bytes in the output hex string. */
   public HexEncoder()
   {
-    this(false);
+    this(false, false);
   }
 
   /**
-   * Creates a new instance with optional delimiting of bytes in the output hex string.
+   * Creates a new instance with optional colon-delimiting of bytes.
    *
    * @param  delimitBytes  True to delimit every two characters (i.e. every byte) with ':' character.
    */
   public HexEncoder(final boolean delimitBytes)
   {
+    this(delimitBytes, false);
+  }
+
+
+  /**
+   * Creates a new instance with optional colon-delimiting of bytes and uppercase output.
+   *
+   * @param  delimitBytes  True to delimit every two characters (i.e. every byte) with ':' character.
+   * @param  uppercase  True to output uppercase alphabetic characters, false for lowercase.
+   */
+  public HexEncoder(final boolean delimitBytes, final boolean uppercase)
+  {
     delimit = delimitBytes;
+    table = uppercase ? UC_ENCODING_TABLE : LC_ENCODING_TABLE;
   }
 
 
@@ -52,8 +70,8 @@ public class HexEncoder implements Encoder
     byte current;
     while (input.hasRemaining()) {
       current = input.get();
-      output.put(ENCODING_TABLE[(current & 0xf0) >> 4]);
-      output.put(ENCODING_TABLE[current & 0x0f]);
+      output.put(table[(current & 0xf0) >> 4]);
+      output.put(table[current & 0x0f]);
       if (delimit && input.hasRemaining()) {
         output.put(':');
       }
@@ -73,5 +91,19 @@ public class HexEncoder implements Encoder
       size += inputSize - 1;
     }
     return size;
+  }
+
+
+  /**
+   * Initializes the encoding table for the given character set.
+   *
+   * @param  charset  Character set.
+   * @param  table  Encoding table.
+   */
+  private static void initTable(final String charset, final char[] table)
+  {
+    for (int i = 0; i < charset.length(); i++) {
+      table[i] = charset.charAt(i);
+    }
   }
 }

--- a/src/main/java/org/cryptacular/spec/CodecSpec.java
+++ b/src/main/java/org/cryptacular/spec/CodecSpec.java
@@ -2,6 +2,7 @@
 package org.cryptacular.spec;
 
 
+import org.cryptacular.codec.Base32Codec;
 import org.cryptacular.codec.Base64Codec;
 import org.cryptacular.codec.Codec;
 import org.cryptacular.codec.HexCodec;
@@ -18,8 +19,26 @@ public class CodecSpec implements Spec<Codec>
   /** Hexadecimal encoding specification. */
   public static final CodecSpec HEX = new CodecSpec("Hex");
 
+  /** Lowercase hexadecimal encoding specification. */
+  public static final CodecSpec HEX_LOWER = new CodecSpec("Hex-Lower");
+
+  /** Uppercase hexadecimal encoding specification. */
+  public static final CodecSpec HEX_UPPER = new CodecSpec("Hex-Upper");
+
+  /** Base32 encoding specification. */
+  public static final CodecSpec BASE32 = new CodecSpec("Base32");
+
+  /** Unpadded base32 encoding specification. */
+  public static final CodecSpec BASE32_UNPADDED = new CodecSpec("Base32-Unpadded");
+
   /** Base64 encoding specification. */
   public static final CodecSpec BASE64 = new CodecSpec("Base64");
+
+  /** URL-safe base64 encoding specification. */
+  public static final CodecSpec BASE64_URLSAFE = new CodecSpec("Base64-URLSafe");
+
+  /** Unpadded base64 encoding specification. */
+  public static final CodecSpec BASE64_UNPADDED = new CodecSpec("Base64-Unpadded");
 
 
   /** Name of encoding, e.g. "Hex, "Base64". */
@@ -40,7 +59,7 @@ public class CodecSpec implements Spec<Codec>
   }
 
 
-  /** @return  The name of the encoding, e.g. "Hex", "Base64". */
+  /** @return  The name of the encoding, e.g. "Hex", "Base32", "Base64". */
   @Override
   public String getAlgorithm()
   {
@@ -52,10 +71,20 @@ public class CodecSpec implements Spec<Codec>
   public Codec newInstance()
   {
     final Codec codec;
-    if ("Hex".equalsIgnoreCase(encoding)) {
+    if ("Hex".equalsIgnoreCase(encoding) || "Hex-Lower".equalsIgnoreCase(encoding)) {
       codec = new HexCodec();
+    } else if ("Hex-Upper".equalsIgnoreCase(encoding)) {
+      codec = new HexCodec(true);
+    } else if ("Base32".equalsIgnoreCase(encoding) || "Base-32".equalsIgnoreCase(encoding)) {
+      codec = new Base32Codec();
+    } else if ("Base32-Unpadded".equalsIgnoreCase(encoding)) {
+      codec = new Base32Codec("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", true);
     } else if ("Base64".equalsIgnoreCase(encoding) || "Base-64".equalsIgnoreCase(encoding)) {
       codec = new Base64Codec();
+    } else if ("Base64-URLSafe".equalsIgnoreCase(encoding)) {
+      codec = new Base64Codec("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");
+    } else if ("Base64-Unpadded".equalsIgnoreCase(encoding)) {
+      codec = new Base64Codec("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", false);
     } else {
       throw new IllegalArgumentException("Invalid encoding.");
     }

--- a/src/test/java/org/cryptacular/codec/HexDecoderTest.java
+++ b/src/test/java/org/cryptacular/codec/HexDecoderTest.java
@@ -24,7 +24,7 @@ public class HexDecoderTest
     return
       new Object[][] {
         new Object[] {
-          "41626c652077617320492065726520492073617720656c6261",
+          "41626C652077617320492065726520492073617720656C6261",
           "Able was I ere I saw elba",
         },
         new Object[] {

--- a/src/test/java/org/cryptacular/codec/HexEncoderTest.java
+++ b/src/test/java/org/cryptacular/codec/HexEncoderTest.java
@@ -29,9 +29,9 @@ public class HexEncoderTest
           "41626c652077617320492065726520492073617720656c6261",
         },
         new Object[] {
-          new HexEncoder(false),
+          new HexEncoder(false, true),
           ByteUtil.toBytes("Able was I ere I saw elba\n"),
-          "41626c652077617320492065726520492073617720656c62610a",
+          "41626C652077617320492065726520492073617720656C62610A",
         },
         new Object[] {
           new HexEncoder(true),


### PR DESCRIPTION
Both HexEncoder and HexCodec expose flag for uppercase output. Note HexDecoder already supports decoding in either case. Fixes #47 