### PR TITLE
Clarify dual license choice #46

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-This product is dual licensed under both the Apache2 and LGPL licenses.
-See LICENSE-apache2 and LICENSE-lgpl.
+This product is dual licensed under a choice of either the Apache-2.0 or the LGPL-3.0 license. 
+See LICENSE-apache2 and LICENSE-lgpl for the full text of the licenses.


### PR DESCRIPTION
This clarifies that the license is a choice of the Apache-2.0 or the LGPL-3.0 license.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>