### PR TITLE
Decouple CertUtil to use both BC and BCFIPS

### DIFF
--- a/src/main/java/org/cryptacular/util/CertUtil.java
+++ b/src/main/java/org/cryptacular/util/CertUtil.java
@@ -10,6 +10,8 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -37,7 +39,6 @@ import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -596,7 +597,9 @@ public final class CertUtil
     final BigInteger serial = BigInteger.valueOf(now.toEpochMilli());
 
     try {
-      final ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgo).build(keyPair.getPrivate());
+      final Provider provider = bouncyCastleProvider();
+      final ContentSigner contentSigner =
+        new JcaContentSignerBuilder(signatureAlgo).setProvider(provider).build(keyPair.getPrivate());
       final X500Name x500Name = new X500Name(RFC4519Style.INSTANCE, dn);
       final X509v3CertificateBuilder certificateBuilder =
         new JcaX509v3CertificateBuilder(x500Name,
@@ -607,9 +610,27 @@ public final class CertUtil
           keyPair.getPublic())
           .addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
       return new JcaX509CertificateConverter()
-        .setProvider(new BouncyCastleProvider()).getCertificate(certificateBuilder.build(contentSigner));
+        .setProvider(provider).getCertificate(certificateBuilder.build(contentSigner));
     } catch (OperatorCreationException | CertIOException | CertificateException e) {
       throw new RuntimeException("Certificate generation error", e);
+    }
+  }
+
+  static Provider bouncyCastleProvider()
+  {
+    Provider p = Security.getProvider("BCFIPS");
+    if (p != null) {
+      return p;
+    }
+    p = Security.getProvider("BC");
+    if (p != null) {
+      return p;
+    }
+    try {
+      return (Provider) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
+        .getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new IllegalStateException("No BouncyCastle provider found (BC or BCFIPS)", e);
     }
   }
 

--- a/src/main/java/org/cryptacular/util/CsrUtil.java
+++ b/src/main/java/org/cryptacular/util/CsrUtil.java
@@ -271,7 +271,8 @@ public final class CsrUtil
         throw new CryptoException("Error adding subject alt names to CSR", e);
       }
     }
-    final JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(sigAlg);
+    final JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(sigAlg)
+        .setProvider(CertUtil.bouncyCastleProvider());
     try {
       final ContentSigner signer = csBuilder.build(keyPair.getPrivate());
       return p10Builder.build(signer);

--- a/src/test/java/org/cryptacular/util/CertUtilTest.java
+++ b/src/test/java/org/cryptacular/util/CertUtilTest.java
@@ -5,7 +5,9 @@ import java.io.File;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
@@ -15,6 +17,7 @@ import java.util.Date;
 import java.util.List;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.cryptacular.FailListener;
 import org.cryptacular.generator.KeyPairGenerator;
 import org.cryptacular.x509.GeneralNameType;
@@ -497,6 +500,49 @@ public class CertUtilTest
       .hasMessage("Unknown signature type requested: UNSUPPORTEDALGO");
   }
 
+
+  @Test
+  public void testBouncyCastleProviderFallsBackToBC()
+  {
+    Security.removeProvider("BC");
+    try {
+      final Provider provider = CertUtil.bouncyCastleProvider();
+      assertThat(provider).isNotNull();
+      assertThat(provider.getName()).isEqualTo("BC");
+    } finally {
+      Security.removeProvider("BC");
+    }
+  }
+
+  @Test
+  public void testBouncyCastleProviderUsesRegisteredBC()
+  {
+    final Provider bc = new BouncyCastleProvider();
+    Security.addProvider(bc);
+    try {
+      final Provider provider = CertUtil.bouncyCastleProvider();
+      assertThat(provider).isSameAs(bc);
+    } finally {
+      Security.removeProvider("BC");
+    }
+  }
+
+  @Test
+  public void testGenX509WithRegisteredBCProvider()
+  {
+    final Provider bc = new BouncyCastleProvider();
+    Security.addProvider(bc);
+    try {
+      final KeyPair keyPair = KeyPairGenerator.generateRSA(new SecureRandom(), 2048);
+      final String dn = "CN=test.example.org,DC=example,DC=org";
+      final X509Certificate cert = CertUtil.generateX509Certificate(
+        keyPair, dn, Duration.ofDays(365), "SHA256WithRSA");
+      assertThat(cert).isNotNull();
+      assertThat(CertUtil.subjectCN(cert)).isEqualTo("test.example.org");
+    } finally {
+      Security.removeProvider("BC");
+    }
+  }
 
   private OffsetDateTime truncateToSeconds(final Instant instant)
   {


### PR DESCRIPTION
This PR was created because of an issue with the chain
From spring-security we load opensaml5 and this uses this project.

Until a certain version is was possible to run spring and opensaml with BCFIPS variant of bouncy castle but with the PR https://github.com/vt-middleware/cryptacular/pull/68 there was a hard dependency to BC introduced.

This PR removes the hard dependency and allows again both providers